### PR TITLE
Ensure Norwegian UI selection uses English granularity values

### DIFF
--- a/src/kpis.py
+++ b/src/kpis.py
@@ -1,9 +1,15 @@
 import streamlit as st
 import numpy as np
 
+
 def compute_kpis(edf, gdf):
     k1, k2, k3, k4 = st.columns(4)
-    with k1: st.metric("Total kWh", f"{gdf['kwh'].sum():,.0f}")
-    with k2: st.metric("Avg kWh/m²", f"{gdf['kwh_per_m2'].mean():.1f}")
-    with k3: st.metric("Avg HDD/day", f"{edf['hdd_17c'].mean():.1f}")
-    with k4: st.metric("Outliers (|z|≥3)", f"{(gdf['z_score'].abs() >= 3).sum()}")
+    with k1:
+        st.metric("Totalt energiforbruk (kWh)", f"{gdf['kwh'].sum():,.0f}")
+    with k2:
+        st.metric("Gjennomsnittlig kWh/m²", f"{gdf['kwh_per_m2'].mean():.1f}")
+    with k3:
+        st.metric("Gjennomsnittlig HDD/dag", f"{edf['hdd_17c'].mean():.1f}")
+    with k4:
+        st.metric("Antall avvik (|z|≥3)", f"{(gdf['z_score'].abs() >= 3).sum()}")
+


### PR DESCRIPTION
## Summary
- Map Norwegian granularity labels to English values so data aggregation functions operate correctly
- Show selected granularity in Norwegian while keeping internal representation in English
- Translate remaining UI elements and KPI labels to Norwegian

## Testing
- `python -m py_compile app.py src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2cfc7b220832e99438b45115930ef