### PR TITLE
feat: load real project data from csv

### DIFF
--- a/data/static_data.csv
+++ b/data/static_data.csv
@@ -1,0 +1,2 @@
+project_type,project_id,city,project_name,year_built,lat,lon,total_HE,Total_BRA
+studentboliger,200,Trondheim,Berg studentby,2010,63.4140277,10.4173132,668,16005

--- a/data/temperature_data.csv
+++ b/data/temperature_data.csv
@@ -1,0 +1,2 @@
+City,Time,Temperature
+Trondheim,01.08.2020,14.2

--- a/src/data.py
+++ b/src/data.py
@@ -1,11 +1,34 @@
+from __future__ import annotations
+
 from datetime import date
+from pathlib import Path
+from typing import Tuple
+
 import numpy as np
 import pandas as pd
 import streamlit as st
+
 from src.constants import CITY_VIEWS
 
-@st.cache_data
-def load_data():
+
+# ---------------------------------------------------------------------------
+# Synthetic fallback --------------------------------------------------------
+# ---------------------------------------------------------------------------
+
+def _load_synthetic() -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Generate synthetic demo data.
+
+    Returns
+    -------
+    buildings : pd.DataFrame
+        Static information about each building/project.
+    energy : pd.DataFrame
+        Daily energy use per building.
+    total_he : pd.DataFrame
+        Static capacity (number of students) per building.
+    weather : pd.DataFrame
+        Daily weather for each city.
+    """
     rng = np.random.default_rng(42)
     rows = []
     for city, v in CITY_VIEWS.items():
@@ -14,56 +37,145 @@ def load_data():
             lon = v["lon"] + rng.normal(0, 0.02)
             area = int(rng.integers(1500, 8000))
             capacity = int(rng.integers(80, 450))
-            rows.append(dict(
-                building_id=f"{city[:2].upper()}_{i+1}",
-                city=city, name=f"{city} Studenthus {i+1}",
-                lat=float(lat), lon=float(lon), area_m2=area,
-                capacity_students=capacity
-            ))
+            rows.append(
+                dict(
+                    building_id=f"{city[:2].upper()}_{i+1}",
+                    city=city,
+                    name=f"{city} Studenthus {i+1}",
+                    lat=float(lat),
+                    lon=float(lon),
+                    area_m2=area,
+                    capacity_students=capacity,
+                )
+            )
     buildings = pd.DataFrame(rows)
+    total_he = buildings[["building_id", "capacity_students"]].rename(
+        columns={"capacity_students": "total_HE"}
+    )
 
-    dates = pd.date_range(end=date.today(), periods=365*3, freq="D")
-    energy, occupancy, weather = [], [], []
+    dates = pd.date_range(end=date.today(), periods=365 * 3, freq="D")
+    energy, weather = [], []
     for _, b in buildings.iterrows():
-        base = float(np.clip(b["area_m2"]/10, 150, 900))
+        base = float(np.clip(b["area_m2"] / 10, 150, 900))
         for d in dates:
             doy = d.timetuple().tm_yday
-            temp = float(8 + 10*np.sin(2*np.pi*doy/365) + np.random.normal(0,2))
+            temp = float(8 + 10 * np.sin(2 * np.pi * doy / 365) + rng.normal(0, 2))
             hdd = float(max(0, 17 - temp))
-            occ = int(0.8*b["capacity_students"] + np.random.normal(0, 10))
-            kwh = float(base + 30*hdd + 0.6*occ + np.random.normal(0, 80))
-            energy.append(dict(date=d, building_id=b.building_id, kwh=max(kwh, 0.0)))
-            occupancy.append(dict(date=d, building_id=b.building_id, occupants=max(occ, 0)))
-            weather.append(dict(date=d, city=b.city, temp_mean_c=temp, hdd_17c=hdd))
+            occ = int(0.8 * b["capacity_students"] + rng.normal(0, 10))
+            kwh = float(base + 30 * hdd + 0.6 * occ + rng.normal(0, 80))
+            energy.append(
+                dict(date=d, building_id=b.building_id, kwh=max(kwh, 0.0))
+            )
+            weather.append(
+                dict(date=d, city=b.city, temp_mean_c=temp, hdd_17c=hdd)
+            )
 
-    weather_df = pd.DataFrame(weather).drop_duplicates(subset=["date","city"])
-    return buildings, pd.DataFrame(energy), pd.DataFrame(occupancy), weather_df
+    weather_df = pd.DataFrame(weather).drop_duplicates(subset=["date", "city"])
+    return buildings, pd.DataFrame(energy), total_he, weather_df
 
-def aggregate_data(edf, bdf, granularity):
-    if granularity == "Day":
-        out = edf
-    elif granularity == "Month":
+
+# ---------------------------------------------------------------------------
+# CSV ingestion -------------------------------------------------------------
+# ---------------------------------------------------------------------------
+
+def _load_from_csv(data_dir: Path) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Load project and weather data from CSV files."""
+    static_path = data_dir / "static_data.csv"
+    temp_path = data_dir / "temperature_data.csv"
+
+    static_df = pd.read_csv(static_path)
+    buildings = static_df.rename(
+        columns={
+            "project_id": "building_id",
+            "project_name": "name",
+            "Total_BRA": "area_m2",
+            "total_HE": "capacity_students",
+        }
+    )
+    buildings["building_id"] = buildings["building_id"].astype(str)
+    buildings = buildings[
+        [
+            "building_id",
+            "city",
+            "name",
+            "year_built",
+            "lat",
+            "lon",
+            "area_m2",
+            "capacity_students",
+        ]
+    ]
+    total_he = buildings[["building_id", "capacity_students"]].rename(
+        columns={"capacity_students": "total_HE"}
+    )
+
+    weather = pd.read_csv(temp_path, parse_dates=["Time"], dayfirst=True)
+    weather = weather.rename(
+        columns={"City": "city", "Time": "date", "Temperature": "temp_mean_c"}
+    )
+    weather["days_in_month"] = weather["date"].dt.days_in_month
+    weather["hdd_17c"] = (
+        (17 - weather["temp_mean_c"]).clip(lower=0) * weather["days_in_month"]
+    )
+
+    # Dummy monthly energy data based on static attributes and weather
+    energy_rows = []
+    for _, wrow in weather.iterrows():
+        for _, b in buildings.iterrows():
+            base = float(
+                np.clip(b["area_m2"] / 10, 150, 900) * wrow["days_in_month"]
+            )
+            kwh = float(base + 30 * wrow["hdd_17c"] + 0.6 * b["capacity_students"])
+            energy_rows.append(
+                {
+                    "date": wrow["date"],
+                    "building_id": b["building_id"],
+                    "kwh": kwh,
+                }
+            )
+    energy = pd.DataFrame(energy_rows)
+
+    return buildings, energy, total_he, weather.drop(columns=["days_in_month"])
+
+
+# ---------------------------------------------------------------------------
+# Public API ---------------------------------------------------------------
+# ---------------------------------------------------------------------------
+
+@st.cache_data
+def load_data(use_csv: bool = False, data_dir: Path | str = Path("data")):
+    """Load data either from CSV files or using the synthetic fallback."""
+    data_path = Path(data_dir)
+    if use_csv:
+        return _load_from_csv(data_path)
+    return _load_synthetic()
+
+
+def aggregate_data(edf: pd.DataFrame, bdf: pd.DataFrame, granularity: str) -> pd.DataFrame:
+    if granularity == "Month":
         out = (
             edf.assign(month=lambda x: x["date"].values.astype("datetime64[M]"))
-              .groupby(["month", "building_id"], as_index=False)[["kwh","occupants","hdd_17c"]].sum()
-              .rename(columns={"month":"date"})
+               .groupby(["month", "building_id"], as_index=False)
+               .agg({"kwh": "sum", "hdd_17c": "sum", "total_HE": "first"})
+               .rename(columns={"month": "date"})
         )
     elif granularity == "Year":
         out = (
             edf.assign(year=lambda x: x["date"].dt.year)
-              .groupby(["year","building_id"], as_index=False)[["kwh","occupants","hdd_17c"]].sum()
-              .rename(columns={"year":"date"})
+               .groupby(["year", "building_id"], as_index=False)
+               .agg({"kwh": "sum", "hdd_17c": "sum", "total_HE": "first"})
+               .rename(columns={"year": "date"})
         )
         out["date"] = pd.to_datetime(out["date"].astype(str) + "-01-01")
     else:
         out = edf
 
     out = out.merge(
-        bdf[["building_id","area_m2","name","lat","lon"]],
+        bdf[["building_id", "area_m2", "name", "lat", "lon"]],
         on="building_id",
-        how="left"
+        how="left",
     )
-    out["expected_kwh"] = 30*out["hdd_17c"] + 0.5*out["occupants"]
+    out["expected_kwh"] = 30 * out["hdd_17c"] + 0.5 * out["total_HE"]
     out["residual"] = out["kwh"] - out["expected_kwh"]
     out["kwh_per_m2"] = out["kwh"] / out["area_m2"].replace(0, np.nan)
     from src.utils import robust_z_scores

--- a/src/map.py
+++ b/src/map.py
@@ -3,22 +3,37 @@ import pandas as pd
 import pydeck as pdk
 from src.constants import BASEMAP_CONFIGS, MAPBOX_TOKEN
 
+
 def z_to_color(z: float) -> list[int]:
-    if z > 1.5:   return [220, 30, 30, 200]
-    if z > 0.5:   return [250, 150, 20, 200]
-    if z < -1.5:  return [30, 80, 220, 200]
-    if z < -0.5:  return [80, 180, 250, 200]
+    if z > 1.5:
+        return [220, 30, 30, 200]
+    if z > 0.5:
+        return [250, 150, 20, 200]
+    if z < -1.5:
+        return [30, 80, 220, 200]
+    if z < -0.5:
+        return [80, 180, 250, 200]
     return [200, 200, 200, 200]
 
+
 def build_energy_map(gdf, bdf, city, view, basemap_choice):
-    zs = gdf.groupby("building_id")["z_score"].mean().reindex(bdf["building_id"]).fillna(0).clip(-3, 3)
+    zs = (
+        gdf.groupby("building_id")["z_score"].mean()
+        .reindex(bdf["building_id"])
+        .fillna(0)
+        .clip(-3, 3)
+    )
     bdf = bdf.assign(
+        kwh=gdf.groupby("building_id")["kwh"].sum().reindex(bdf["building_id"]).values,
+        total_HE=gdf.groupby("building_id")["total_HE"].first().reindex(bdf["building_id"]).values,
         kwh_per_m2=gdf.groupby("building_id")["kwh_per_m2"].mean().reindex(bdf["building_id"]).values,
         z_color=[z_to_color(z) for z in zs.values],
-        radius=(bdf["area_m2"] / 5).clip(150, 800)
+        radius=(bdf["area_m2"] / 5).clip(150, 800),
     )
 
-    view_state = pdk.ViewState(latitude=view["lat"], longitude=view["lon"], zoom=view["zoom"], pitch=45)
+    view_state = pdk.ViewState(
+        latitude=view["lat"], longitude=view["lon"], zoom=view["zoom"], pitch=45
+    )
     points_layer = pdk.Layer(
         "ScatterplotLayer",
         data=bdf,
@@ -27,6 +42,11 @@ def build_energy_map(gdf, bdf, city, view, basemap_choice):
         get_fill_color="z_color",
         pickable=True,
     )
+
+    tooltip = {
+        "html": "<b>{name}</b><br/>kWh: {kwh:.0f}<br/>Students: {total_HE}",
+        "style": {"color": "white"},
+    }
 
     config = BASEMAP_CONFIGS.get(basemap_choice, BASEMAP_CONFIGS["OpenStreetMap (no token)"])
     if config["provider"] == "osm":
@@ -39,13 +59,14 @@ def build_energy_map(gdf, bdf, city, view, basemap_choice):
             opacity=1.0,
             pickable=False,
         )
-        return pdk.Deck(layers=[osm_layer, points_layer], initial_view_state=view_state)
+        return pdk.Deck(layers=[osm_layer, points_layer], initial_view_state=view_state, tooltip=tooltip)
     elif config["provider"] == "carto":
         return pdk.Deck(
             layers=[points_layer],
             initial_view_state=view_state,
             map_provider="carto",
             map_style=config["style"],
+            tooltip=tooltip,
         )
     else:
         kwargs = dict(
@@ -53,6 +74,7 @@ def build_energy_map(gdf, bdf, city, view, basemap_choice):
             initial_view_state=view_state,
             map_provider="mapbox",
             map_style=config["style"],
+            tooltip=tooltip,
         )
         if MAPBOX_TOKEN:
             kwargs["api_keys"] = {"mapbox": MAPBOX_TOKEN}


### PR DESCRIPTION
## Summary
- handle monthly mean temperature by multiplying by days when computing HDD
- drop daily granularity, keeping month and year views only

## Testing
- `python -m py_compile src/data.py app.py src/map.py`
- `python - <<'PY'
from src.data import load_data, aggregate_data
b,e,t,w = load_data(use_csv=True)
print('buildings', b.head(), sep='\n')
print('energy', e.head(), sep='\n')
print('total_he', t.head(), sep='\n')
print('weather', w.head(), sep='\n')
edf = e.merge(t, on='building_id').merge(b[['building_id']], on='building_id').merge(w, on='date')
print('agg_month', aggregate_data(edf, b, 'Month').head(), sep='\n')
print('agg_year', aggregate_data(edf, b, 'Year').head(), sep='\n')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a57de7ab98832e8a52d4a45ce6a322