### PR TITLE
Add flexible filtering and column metrics

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -244,6 +244,7 @@ def aggregate_data(edf: pd.DataFrame, bdf: pd.DataFrame, granularity: str) -> pd
     out["expected_kwh"] = 30 * out["hdd_17c"] + 0.5 * out["total_HE"]
     out["residual"] = out["kwh"] - out["expected_kwh"]
     out["kwh_per_m2"] = out["kwh"] / out["area_m2"].replace(0, np.nan)
+    out["kwh_per_student"] = out["kwh"] / out["total_HE"].replace(0, np.nan)
     from src.utils import robust_z_scores
     out["z_score"] = robust_z_scores(out["residual"].to_numpy())
     return out


### PR DESCRIPTION
## Summary
- Add sidebar controls to choose column height metric (total energy, per student, per m²)
- Replace date range with year and month filters, including month-over-years comparison
- Support kWh per student metric in data and map rendering

## Testing
- `python -m pytest`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5bd80a418832e9dc08222acb38d8c