### PR TITLE
Remove project selection in favour of map-based details

### DIFF
--- a/src/map.py
+++ b/src/map.py
@@ -52,8 +52,22 @@ def build_energy_map(gdf, bdf, city, view, basemap_choice, metric: str = "kwh"):
     # Filter out rows with missing values needed for visualization
     bdf = bdf.dropna(subset=["value", "lon", "lat"])
 
-    # Convert to Python dicts for pydeck compatibility
-    data_records = bdf[["lon", "lat", "value", "radius", "color"]].to_dict(orient="records")
+    # Convert to Python dicts for pydeck compatibility including details for tooltips
+    data_records = bdf[
+        [
+            "lon",
+            "lat",
+            "value",
+            "radius",
+            "color",
+            "name",
+            "kwh",
+            "kwh_per_student",
+            "kwh_per_m2",
+            "total_HE",
+            "area_m2",
+        ]
+    ].to_dict(orient="records")
 
     # View
     view_state = pdk.ViewState(


### PR DESCRIPTION
## Summary
- Remove side panel project multiselect and compute KPIs for all buildings
- Configure map with building metrics so clicking columns reveals project details

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a85494a06c832eac13201c4c02de2d